### PR TITLE
💎 Use better supported emoji for features

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -5,8 +5,8 @@ interface Group {
 
 export const orderedGroups: Group[] = [
   {
-    label: '### Features 🧬:',
-    matcher: message => /.*(feature|feat|🧬|experiment).*/i.test(message),
+    label: '### Features 💎:',
+    matcher: message => /.*(feature|feat|💎|experiment).*/i.test(message),
   },
   {
     label: '### Enhancements ⚡️:',


### PR DESCRIPTION
In my personal mac the DNA emoji on the features doesn't works, it was released on the [emoji version 11.0](https://emojipedia.org/emoji-11.0/) and for some reason I still don't have it 🤷‍♂